### PR TITLE
fix TypeError: CharmBase.__init__() takes 2 positional arguments but 3 were given

### DIFF
--- a/tests/test_e2e/test_state.py
+++ b/tests/test_e2e/test_state.py
@@ -49,8 +49,8 @@ def mycharm():
         called = False
         on = MyCharmEvents()
 
-        def __init__(self, framework: Framework, key: Optional[str] = None):
-            super().__init__(framework, key)
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
             for evt in self.on.events().values():
                 self.framework.observe(evt, self._on_event)
 


### PR DESCRIPTION
While running `test_state.py` I get:

```python
Traceback (most recent call last):
  File "/home/jose/trabajos/canonical/repos/traefik-k8s-operator/.tox/scenario/lib/python3.10/site-packages/scenario/runtime.py", line 264, in play
    mocked_main(
  File "/home/jose/trabajos/canonical/repos/traefik-k8s-operator/.tox/scenario/lib/python3.10/site-packages/scenario/ops_main_mock.py", line 113, in main
    charm = charm_class(framework)
  File "/home/jose/trabajos/canonical/repos/traefik-k8s-operator/tests/scenario/test_relations.py", line 57, in __init__
    super().__init__(framework, key)
TypeError: CharmBase.__init__() takes 2 positional arguments but 3 were given

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/jose/trabajos/canonical/repos/traefik-k8s-operator/tests/scenario/test_relations.py", line 245, in test_relation_set
    out = scenario.play(scene, pre_event=pre_event)
  File "/home/jose/trabajos/canonical/repos/traefik-k8s-operator/.tox/scenario/lib/python3.10/site-packages/scenario/scenario.py", line 72, in play
    return self._runtime.play(
  File "/home/jose/trabajos/canonical/repos/traefik-k8s-operator/.tox/scenario/lib/python3.10/site-packages/scenario/runtime.py", line 270, in play
    raise RuntimeError(
RuntimeError: Uncaught error in operator/charm code: CharmBase.__init__() takes 2 positional arguments but 3 were given.
```


This PR fixes that.

After the fix I get:

```
========================================================= test session starts ==========================================================
platform linux -- Python 3.10.7, pytest-7.2.1, pluggy-1.0.0 -- /home/jose/trabajos/canonical/repos/traefik-k8s-operator/.tox/scenario/bin/python
cachedir: .tox/scenario/.pytest_cache
rootdir: /home/jose/trabajos/canonical/repos/traefik-k8s-operator, configfile: pyproject.toml
plugins: anyio-3.6.2
collected 7 items                                                                                                                      

tests/scenario/test_relations.py::test_bare_event PASSED
tests/scenario/test_relations.py::test_leader_get PASSED
tests/scenario/test_relations.py::test_status_setting PASSED
tests/scenario/test_relations.py::test_container[True] PASSED
tests/scenario/test_relations.py::test_container[False] PASSED
tests/scenario/test_relations.py::test_relation_get PASSED
tests/scenario/test_relations.py::test_relation_set PASSED
```

:-)