### PR TITLE
scenario.utils.capture_events

### DIFF
--- a/scenario/utils.py
+++ b/scenario/utils.py
@@ -11,11 +11,13 @@ def capture_events(*types: Type[EventBase], include_lifecycle_events=False):
     If no types are passed, will capture all types.
     """
     def _filter(evt):
-        if not include_lifecycle_events and isinstance(evt, (CommitEvent, PreCommitEvent)):
+        if isinstance(evt, (CommitEvent, PreCommitEvent)):
+            if include_lifecycle_events:
+                return True
             return False
         if types:
             return isinstance(evt, types)
-        return isinstance(evt, EventBase)
+        return True
 
     captured = []
     _real_emit = Framework._emit  # type: ignore # noqa # ugly

--- a/scenario/utils.py
+++ b/scenario/utils.py
@@ -1,0 +1,32 @@
+from contextlib import contextmanager
+from typing import Type
+
+from ops.framework import EventBase, Framework, CommitEvent, PreCommitEvent
+
+
+@contextmanager
+def capture_events(*types: Type[EventBase], include_lifecycle_events=False):
+    """Capture all events of type `*types` (using instance checks).
+
+    If no types are passed, will capture all types.
+    """
+    def _filter(evt):
+        if not include_lifecycle_events and isinstance(evt, (CommitEvent, PreCommitEvent)):
+            return False
+        if types:
+            return isinstance(evt, types)
+        return isinstance(evt, EventBase)
+
+    captured = []
+    _real_emit = Framework._emit  # type: ignore # noqa # ugly
+
+    def _wrapped_emit(_self, evt):
+        if _filter(evt):
+            captured.append(evt)
+        return _real_emit(_self, evt)
+
+    Framework._emit = _wrapped_emit  # type: ignore # noqa # ugly
+
+    yield captured
+
+    Framework._emit = _real_emit  # type: ignore # noqa # ugly

--- a/tests/test_e2e/test_capture_events.py
+++ b/tests/test_e2e/test_capture_events.py
@@ -1,6 +1,6 @@
 import pytest
 from ops.charm import CharmBase, CharmEvents, StartEvent
-from ops.framework import EventSource, EventBase
+from ops.framework import EventSource, EventBase, CommitEvent, PreCommitEvent
 
 from scenario import State
 from scenario.utils import capture_events
@@ -60,5 +60,8 @@ def test_capture_lifecycle(mycharm):
     with capture_events(FooEvent, include_lifecycle_events=True) as captured:
         State().trigger('start', mycharm, meta=mycharm.META)
 
-    assert len(captured) == 1
-    assert isinstance(captured[0], FooEvent)
+    assert len(captured) == 3
+    foo, precomm, comm = captured
+    assert isinstance(foo, FooEvent)
+    assert isinstance(comm, CommitEvent)
+    assert isinstance(precomm, PreCommitEvent)

--- a/tests/test_e2e/test_capture_events.py
+++ b/tests/test_e2e/test_capture_events.py
@@ -1,0 +1,64 @@
+import pytest
+from ops.charm import CharmBase, CharmEvents, StartEvent
+from ops.framework import EventSource, EventBase
+
+from scenario import State
+from scenario.utils import capture_events
+
+
+class FooEvent(EventBase):
+    pass
+
+
+@pytest.fixture
+def mycharm():
+    class MyCharmEvents(CharmEvents):
+        foo = EventSource(FooEvent)
+
+    class MyCharm(CharmBase):
+        META = {'name': 'mycharm'}
+        on = MyCharmEvents()
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            for evt in self.on.events().values():
+                self.framework.observe(evt, self._on_event)
+
+        def _on_event(self, e):
+            if not isinstance(e, FooEvent):
+                self.on.foo.emit()
+
+    return MyCharm
+
+
+def test_capture_all(mycharm):
+    with capture_events() as captured:
+        State().trigger('start', mycharm, meta=mycharm.META)
+
+    assert len(captured) == 2
+    start, foo = captured
+    assert isinstance(start, StartEvent)
+    assert isinstance(foo, FooEvent)
+
+
+def test_capture_start(mycharm):
+    with capture_events(StartEvent) as captured:
+        State().trigger('start', mycharm, meta=mycharm.META)
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], StartEvent)
+
+
+def test_capture_foo(mycharm):
+    with capture_events(FooEvent) as captured:
+        State().trigger('start', mycharm, meta=mycharm.META)
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], FooEvent)
+
+
+def test_capture_lifecycle(mycharm):
+    with capture_events(FooEvent, include_lifecycle_events=True) as captured:
+        State().trigger('start', mycharm, meta=mycharm.META)
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], FooEvent)


### PR DESCRIPTION
This seems like a common-enough use case that we should offer it in this lib, instead of forcing users to install a separate extension or copy-paste code around.
see: https://discourse.charmhub.io/t/harness-recipe-capture-events/6581
for the Harness equivalent.